### PR TITLE
Fixed to stop the spinner when an error occurs

### DIFF
--- a/cmd/stats.go
+++ b/cmd/stats.go
@@ -49,6 +49,7 @@ func workflowStats(cfg config, opt options, isJobs bool) error {
 		return err
 	}
 	s.Start()
+	defer s.Stop()
 
 	runs, err := client.FetchWorkflowRuns(ctx, &github.WorkflowRunsConfig{
 		Org:              cfg.org,


### PR DESCRIPTION
When an error occurs during fetch due to incorrect specifications of GitHub organization(-o) or GitHub repository(-r) etc in command line options, my terminal cursor disappears. 
This seems to be caused by not stopping the spinner's drawing process.

In this fix, the stop process will also be executed in the event of an error.