### PR TITLE
fix error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,13 @@ This tool retrieves workflow execution statistics using the GitHub API. For more
 - [Workflow runs](https://docs.github.com/en/rest/actions/workflow-runs?apiVersion=2022-11-28#list-workflow-runs-for-a-workflow)
 - [Workflow jobs](https://docs.github.com/en/rest/actions/workflow-jobs?apiVersion=2022-11-28#get-a-job-for-a-workflow-run)
 
+## Rate Limiting
+
+GitHub imposes a [primary rate limit](https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api?apiVersion=2022-11-28#about-primary-rate-limits) and a [secondary rate limit](https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api?apiVersion=2022-11-28#about-secondary-rate-limits) on all API clients.
+
+When you reach the primary rate limit, results are calculated based on successful fetches.
+In the secondary rate limit, this tool handles requests in a round-tripper to avoid the rate limit. Therefore, the execution time may be longer.
+
 ## Standard Output
 
 [Sample output](./sample/std-output.txt)
@@ -341,3 +348,4 @@ Each object in the `steps_summary` array includes:
 ]
 }
 ```
+

--- a/cmd/stats.go
+++ b/cmd/stats.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 
@@ -77,7 +78,7 @@ func workflowStats(cfg config, opt options, isJobs bool) error {
 	},
 	)
 	if err != nil {
-		if _, ok := err.(github.RateLimitError); ok {
+		if errors.As(err, &github.RateLimitError{}) {
 			isRateLimit = true
 		} else {
 			return err
@@ -96,7 +97,7 @@ func workflowStats(cfg config, opt options, isJobs bool) error {
 			Repo: cfg.repo,
 		})
 		if err != nil {
-			if _, ok := err.(github.RateLimitError); ok {
+			if errors.As(err, &github.RateLimitError{}) {
 				isRateLimit = true
 			} else {
 				return err

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/briandowns/spinner v1.23.0
 	github.com/cli/go-gh v1.2.1
 	github.com/fatih/color v1.7.0
+	github.com/gofri/go-github-ratelimit v1.1.0
 	github.com/google/go-github/v60 v60.0.0
 	github.com/montanaflynn/stats v0.7.1
 	github.com/spf13/cobra v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
+github.com/gofri/go-github-ratelimit v1.1.0 h1:ijQ2bcv5pjZXNil5FiwglCg8wc9s8EgjTmNkqjw8nuk=
+github.com/gofri/go-github-ratelimit v1.1.0/go.mod h1:OnCi5gV+hAG/LMR7llGhU7yHt44se9sYgKPnafoL7RY=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=

--- a/internal/github/auth.go
+++ b/internal/github/auth.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/cli/go-gh/pkg/auth"
+	"github.com/gofri/go-github-ratelimit/github_ratelimit"
 	"github.com/google/go-github/v60/github"
 )
 
@@ -31,8 +32,12 @@ func NewClient(host string, authenticator Authenticator) (*WorkflowStatsClient, 
 	if err != nil {
 		return nil, err
 	}
+	r, err := github_ratelimit.NewRateLimitWaiterClient(nil)
+	if err != nil {
+		return nil, err
+	}
 
-	client := github.NewClient(nil).WithAuthToken(token)
+	client := github.NewClient(r).WithAuthToken(token)
 	if host != "github.com" {
 		client.BaseURL.Host = host
 		client.BaseURL.Path = "/api/v3/"

--- a/internal/github/jobs.go
+++ b/internal/github/jobs.go
@@ -32,8 +32,14 @@ func (c *WorkflowStatsClient) FetchWorkflowJobsAttempts(ctx context.Context, run
 				PerPage: perPage,
 			},
 			)
-			if err != nil && resp.StatusCode != http.StatusNotFound {
+			if _, ok := err.(*github.RateLimitError); ok {
+				errCh <- RateLimitError{Err: err}
+				return
+			} else if err != nil && resp.StatusCode != http.StatusNotFound {
 				errCh <- err
+			}
+			if jobs == nil || jobs.Jobs == nil {
+				return
 			}
 			jobsCh <- jobs.Jobs
 

--- a/internal/github/jobs.go
+++ b/internal/github/jobs.go
@@ -2,7 +2,6 @@ package github
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"runtime"
 	"sync"
@@ -33,13 +32,11 @@ func (c *WorkflowStatsClient) FetchWorkflowJobsAttempts(ctx context.Context, run
 				PerPage: perPage,
 			},
 			)
-			if err != nil || resp.StatusCode != http.StatusOK {
+			if err != nil && resp.StatusCode != http.StatusNotFound {
 				errCh <- err
-			} else if jobs == nil || jobs.Jobs == nil {
-				errCh <- fmt.Errorf("no jobs found for run %d", run.GetID())
-			} else {
-				jobsCh <- jobs.Jobs
 			}
+			jobsCh <- jobs.Jobs
+
 		}(run)
 	}
 	wg.Wait()

--- a/internal/github/model.go
+++ b/internal/github/model.go
@@ -1,0 +1,9 @@
+package github
+
+type RateLimitError struct {
+	Err error
+}
+
+func (e RateLimitError) Error() string {
+	return e.Err.Error()
+}

--- a/internal/parser/runs.go
+++ b/internal/parser/runs.go
@@ -42,6 +42,8 @@ type WorkflowRun struct {
 	JobsURL      string    `json:"jobs_url"`
 	LogsURL      string    `json:"logs_url"`
 	RunStartedAt time.Time `json:"run_started_at"`
+	UpdateAt     time.Time `json:"update_at"`
+	CreatedAt    time.Time `json:"created_at"`
 	Duration     float64   `json:"duration"`
 }
 
@@ -94,6 +96,8 @@ func WorkflowRunsParse(wrs []*github.WorkflowRun) *WorkflowRunsStatsSummary {
 			JobsURL:      wr.GetJobsURL(),
 			LogsURL:      wr.GetLogsURL(),
 			RunStartedAt: wr.GetRunStartedAt().Time,
+			UpdateAt:     wr.GetUpdatedAt().Time,
+			CreatedAt:    wr.GetCreatedAt().Time,
 		}
 		d := wr.GetUpdatedAt().Sub(wr.GetRunStartedAt().Time).Seconds()
 		w.Duration = d

--- a/internal/printer/warning.go
+++ b/internal/printer/warning.go
@@ -6,5 +6,5 @@ import (
 )
 
 func RateLimitWarning(w io.Writer) {
-	fmt.Fprintf(w, "\U000026A0 You have reached the rate limit for the GitHub API. These results may not be accurate.\n")
+	fmt.Fprintf(w, "\U000026A0  You have reached the rate limit for the GitHub API. These results may not be accurate.\n\n")
 }

--- a/internal/printer/warning.go
+++ b/internal/printer/warning.go
@@ -1,0 +1,10 @@
+package printer
+
+import (
+	"fmt"
+	"io"
+)
+
+func RateLimitWarning(w io.Writer) {
+	fmt.Fprintf(w, "\U000026A0 You have reached the rate limit for the GitHub API. These results may not be accurate.\n")
+}


### PR DESCRIPTION
close #9 
- **feat: fix 404 error handling**
- **feat: API rate limit error handling**

When it reach the primary rate limit, results are calculated based on successful fetches.
In the secondary rate limit, this tool handles requests in a round-tripper to avoid the rate limit. Therefore, the execution time may be longer.