### PR TITLE
Allow filtering workflows by more than one status value

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -18,7 +18,7 @@ var (
 	actor               string
 	branch              string
 	event               string
-	status              string
+	status              []string
 	created             string
 	headSHA             string
 	excludePullRequests bool
@@ -81,7 +81,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVarP(&actor, "actor", "a", "", "Workflow run actor")
 	rootCmd.PersistentFlags().StringVarP(&branch, "branch", "b", "", "Workflow run branch. Returns workflow runs associated with a branch. Use the name of the branch of the push.")
 	rootCmd.PersistentFlags().StringVarP(&event, "event", "e", "", "Workflow run event. e.g. push, pull_request, pull_request_target, etc.\n See https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows")
-	rootCmd.PersistentFlags().StringVarP(&status, "status", "s", "", "Workflow run status. e.g. completed, in_progress, queued, etc.\n See https://docs.github.com/en/rest/reference/actions#list-workflow-runs-for-a-repository")
+	rootCmd.PersistentFlags().StringSliceVarP(&status, "status", "s", []string{""}, "Workflow run status. e.g. completed, in_progress, queued, etc.\n Multiple values can be provided separated by a comma. For a full list of supported values see https://docs.github.com/en/rest/reference/actions#list-workflow-runs-for-a-repository")
 	rootCmd.PersistentFlags().StringVarP(&created, "created", "c", "", "Workflow run createdAt. Returns workflow runs created within the given date-time range.\n For more information on the syntax, see https://docs.github.com/en/search-github/getting-started-with-searching-on-github/understanding-the-search-syntax#query-for-dates")
 	rootCmd.PersistentFlags().StringVarP(&headSHA, "head-sha", "S", "", "Workflow run head SHA")
 	rootCmd.PersistentFlags().BoolVarP(&excludePullRequests, "exclude-pull-requests", "x", false, "Workflow run exclude pull requests")


### PR DESCRIPTION
This PR turns `--status` flag into a slice of strings, allowing to filter by more than one status value.

Primary motivation for this change is to be able to exclude `cancelled` workflow runs from the success/failure analysis as we are using `cancel-in-progress: true` [workflow setting](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/control-the-concurrency-of-workflows-and-jobs) which results in quite a big number of cancelled jobs that significantly skew reported success/failure rate:

```
$ gh workflow-stats ... --created ">=2024-09-25"
🏃 Total runs: 32
  ✔ Success: 12 (37.5%)
  ✖ Failure: 10 (31.2%)
  🤔 Others: 10 (31.2%)

$ gh workflow-stats ... --created ">=2024-09-25" -s success,failure
🏃 Total runs: 22
  ✔ Success: 12 (54.5%)
  ✖ Failure: 10 (45.5%)
  🤔 Others: 0 (0.0%)
```

P.S.

This PR also fixes a bug where using previous status filter implementation did NOT correctly filter all run attempts by status as only the last attempts were filtered while previous run attempts were added to the result set without filtering by status.