### PR TITLE
fix(gh-extension-precompile): use go_version_file parameter

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,4 +13,4 @@ jobs:
       - uses: actions/checkout@v4
       - uses: cli/gh-extension-precompile@v2
         with:
-          go_version: go.mod
+          go_version_file: go.mod


### PR DESCRIPTION
In the action `cli/gh-extension-precompile@v2` it should use `go_version_file` instead of `go_version_file`. I tested it in a fork as I was receiving the error: 
```bash
extension is not installable: missing executable
```
when running: 
```bash
gh extensions install fchimpan/gh-workflow-stats
```
The reason is probably that the last release action failed https://github.com/fchimpan/gh-workflow-stats/actions/runs/11546366380.